### PR TITLE
Fix bug when file already exists in repo

### DIFF
--- a/.github/scripts/copy_files.py
+++ b/.github/scripts/copy_files.py
@@ -23,10 +23,16 @@ def copy_files(repo, directory, issue_dict):
                 file_path = directory + file_info["filename"]
 
                 # Skip if file already exists in repo
+                file_exists = False
                 try:
                     file_content = repo.get_contents(file_path)
-                    print(f"Skipping {file_key} as the file already exists")
+                    file_exists = True
                 except UnknownObjectException:
+                    file_exists = False
+
+                if file_exists:
+                    print(f"Skipping {file_key} as the file already exists")
+                else:
                     response = requests.get(url)
                     repo.create_file(file_path, "add " + file_info["filename"], response.content)
             else:

--- a/.github/scripts/copy_files.py
+++ b/.github/scripts/copy_files.py
@@ -1,4 +1,5 @@
 import requests
+from github.GithubException import UnknownObjectException
 
 #def copy_files(repo, directory, issue_dict):
 #	file_keys = ["landing_image", "animation", "graphic_abstract", "model_setup_figure"]
@@ -19,7 +20,14 @@ def copy_files(repo, directory, issue_dict):
 
             # Skip if the URL is an empty string
             if url:
-                response = requests.get(url)
-                repo.create_file(directory + file_info["filename"], "add " + file_info["filename"], response.content)
+                file_path = directory + file_info["filename"]
+
+                # Skip if file already exists in repo
+                try:
+                    file_content = repo.get_contents(file_path)
+                    print(f"Skipping {file_key} as the file already exists")
+                except UnknownObjectException:
+                    response = requests.get(url)
+                    repo.create_file(file_path, "add " + file_info["filename"], response.content)
             else:
                 print(f"Skipping {file_key} as the URL is empty")


### PR DESCRIPTION
Code now checks to see if a file already exists in a repo, and skips copying the file across if it does.